### PR TITLE
Update resources.c

### DIFF
--- a/src/resources.c
+++ b/src/resources.c
@@ -57,6 +57,7 @@
 #include "vice-event.h"
 #include "sysfile.h"
 #include "archdep_defs.h"
+#include "archdep_user_config_path.h"
 
 #ifdef VICE_DEBUG_RESOURCES
 #define DBG(x)  printf x


### PR DESCRIPTION
Include archdep_user_config_path.h to prevent compiling erors (implicit declaration).